### PR TITLE
Better format currency

### DIFF
--- a/client/app/helpers/format-currency.js
+++ b/client/app/helpers/format-currency.js
@@ -1,0 +1,10 @@
+import Ember from 'ember';
+
+export function formatCurrency([number], { sep }) {
+  const sep = (sep === undefined) ? '&thinsp;' : sep;
+  const value = number.toString();
+  const groups = value.match(/(\d+?)(?=(\d{3})+(?!\d)|$)/g);
+  return Ember.String.htmlSafe(groups.join(sep));
+}
+
+export default Ember.Helper.helper(formatCurrency);

--- a/client/app/helpers/format-currency.js
+++ b/client/app/helpers/format-currency.js
@@ -1,7 +1,10 @@
 import Ember from 'ember';
 
 export function formatCurrency([number], { sep }) {
-  const sep = (sep === undefined) ? '&thinsp;' : sep;
+  if (typeof sep === 'undefined') {
+    // eslint-disable-next-line no-param-reassign
+    sep = '&thinsp;';
+  }
   const value = number.toString();
   const groups = value.match(/(\d+?)(?=(\d{3})+(?!\d)|$)/g);
   return Ember.String.htmlSafe(groups.join(sep));

--- a/client/app/templates/components/b-order-description.hbs
+++ b/client/app/templates/components/b-order-description.hbs
@@ -16,16 +16,16 @@
     </div>
   </div>
   <div class="b-order__money b-order-money">
-    <span class="b-order-money__available">{{order.money.available}}</span>
+    <span class="b-order-money__available">{{format-currency order.money.available}}</span>
     {{#if order.isReady}}
-      <span class="b-order-money__total">{{order.money.total}}</span>
+      <span class="b-order-money__total">{{format-currency order.money.total}}</span>
     {{else}}
       <span class="b-order-money__total _not-enough"
-            title="Минимальная сумма заказа {{order.money.required}}">
-        {{order.money.total}}
+            title="Минимальная сумма заказа {{format-currency order.money.required sep=' '}}">
+        {{format-currency order.money.total}}
       </span>
       <div class="b-order-money__note">
-        Минимальная сумма заказа {{order.money.required}}
+        Минимальная сумма заказа {{format-currency order.money.required}}
       </div>
     {{/if}}
   </div>

--- a/client/app/templates/components/b-order-group.hbs
+++ b/client/app/templates/components/b-order-group.hbs
@@ -12,8 +12,8 @@
     </div>
 
     <div class="b-order-group__money b-order-money">
-      <span class="b-order-money__available">{{moneyAvailable}}</span>
-      <span class="b-order-money__total">{{moneyTotal}}</span>
+      <span class="b-order-money__available">{{format-currency moneyAvailable}}</span>
+      <span class="b-order-money__total">{{format-currency moneyTotal}}</span>
     </div>
 
     {{b-checkbox class="b-order-group__checkbox"

--- a/client/app/templates/components/b-portion.hbs
+++ b/client/app/templates/components/b-portion.hbs
@@ -12,7 +12,7 @@
       {{portion.text}}
     {{/if}}
   </div>
-  <div class="b-portion__cost">{{portion.cost}}</div>
+  <div class="b-portion__cost">{{format-currency portion.cost}}</div>
   {{b-checkbox checked=portion.paid disabled=isManager
                onchange=(action 'togglePaid' portion)}}
 </div>

--- a/client/app/templates/components/f-order.hbs
+++ b/client/app/templates/components/f-order.hbs
@@ -16,7 +16,9 @@
     {{#if vendor}}
       <div class="f-default__row">
         <a class="f-order__vendor-link" href="{{vendor.url}}">{{vendor.url}}</a>
-        <div class="f-order__vendor-min-cost">Минимальная сумма заказа {{vendor.minOrderCost}}</div>
+        <div class="f-order__vendor-min-cost">
+          Минимальная сумма заказа {{format-currency vendor.minOrderCost}}
+        </div>
       </div>
     {{/if}}
 

--- a/client/app/templates/components/pr-order.hbs
+++ b/client/app/templates/components/pr-order.hbs
@@ -16,13 +16,13 @@
       </div>
     </div>
     <div class="pr-order__money b-order-money">
-      <span class="b-order-money__available">{{order.money.available}}</span>
+      <span class="b-order-money__available">{{format-currency order.money.available}}</span>
       {{#if order.isReady}}
-        <span class="b-order-money__total">{{order.money.total}}</span>
+        <span class="b-order-money__total">{{format-currency order.money.total}}</span>
       {{else}}
         <span class="b-order-money__total _not-enough"
-              title="Минимальная сумма заказа {{order.money.required}}">
-          {{order.money.total}}
+              title="Минимальная сумма заказа {{format-currency order.money.required sep=' '}}">
+          {{format-currency order.money.total}}
         </span>
       {{/if}}
     </div>

--- a/client/app/templates/components/pr-vendor-option.hbs
+++ b/client/app/templates/components/pr-vendor-option.hbs
@@ -2,7 +2,7 @@
   <div class="pr-vendor-option__title">{{data.title}}</div>
   {{#if data.minOrderCost}}
     <div class="pr-vendor-option__min-cost">
-      Минимальная сумма заказа {{data.minOrderCost}}
+      Минимальная сумма заказа {{format-currency data.minOrderCost}}
     </div>
   {{/if}}
 </div>

--- a/client/app/templates/vendors.hbs
+++ b/client/app/templates/vendors.hbs
@@ -3,7 +3,9 @@
     <li class="b-vendors__item">
       <div class="b-vendors__info">
         <span class="b-vendors__title">{{vendor.title}}</span>
-        <span class="b-vendors__cost">Минимальная сумма заказа {{vendor.minOrderCost}}</span>
+        <span class="b-vendors__cost">
+          Минимальная сумма заказа {{format-currency vendor.minOrderCost}}
+        </span>
       </div>
       <a href="{{vendor.url}}" target="_blank"
          class="b-vendors__link">{{vendor.url}}</a>

--- a/client/tests/unit/helpers/format-currency-test.js
+++ b/client/tests/unit/helpers/format-currency-test.js
@@ -1,0 +1,18 @@
+import { formatCurrency } from 'client/helpers/format-currency';
+import { module, test } from 'qunit';
+
+module('Unit | Helper | format currency');
+
+test('should split number into groups', function(assert) {
+  assert.equal(formatCurrency([1234567], { sep: ',' }), '1,234,567');
+});
+
+test('should add thin space between groups by default', function(assert) {
+  assert.equal(formatCurrency([12], {}), '12');
+  assert.equal(formatCurrency([123456789], {}), '123&thinsp;456&thinsp;789');
+  assert.equal(formatCurrency([1234567890], {}), '1&thinsp;234&thinsp;567&thinsp;890');
+});
+
+test('should respect custom separator', function(assert) {
+  assert.equal(formatCurrency([1234], { sep: ' ' }), '1 234');
+});


### PR DESCRIPTION
- Использую более удобный формат для валюты - делю значение на группы по 3 числа и ставлю между ними пробел (`thin space`, если быть точным).
- Для значений в которых не может быть html тегов (`title`) явно использую пробел.
