### PR TITLE
Remove custom rules from eslint config

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,10 +1,4 @@
 {
   "extends": "airbnb/base",
-  "parser": "babel-eslint",
-  "rules": {
-    "comma-dangle": ["error", "never"],
-    "object-shorthand": ["error", "always"],
-    "func-names": "off",
-    "space-before-function-paren": ["error", "never"]
-  }
+  "parser": "babel-eslint"
 }


### PR DESCRIPTION
Prevents fail of Hound CI. Closes #29.
